### PR TITLE
fixing repository link in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.1.0"
 description = "Bump your semantic version of any software using regex"
 authors = ["Ivan Gonzalez <scratchmex@gmail.com>"]
 readme = "README.md"
-repository = "https://github.com/scratchmex/all-relative"
+repository = "https://github.com/scratchmex/manver"
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Just a small, cosmetic fix.
pyproject.toml (and as a result, the project's page on PyPI) links to the wrong project.